### PR TITLE
Added geoscript.defaultMaxFeatures property to plugin.groovy

### DIFF
--- a/plugins/omar-geoscript-plugin/grails-app/conf/plugin.groovy
+++ b/plugins/omar-geoscript-plugin/grails-app/conf/plugin.groovy
@@ -94,4 +94,6 @@ geoscript {
           ]
       ]
   ]
+
+  defaultMaxFeatures = 1000
 }


### PR DESCRIPTION
and defaulted to 1000.   Therefore,  the maximum number of features
returned,  will be this value.   Even if the number of records
exceeds it.   This will prevent the memory/performance issues we
saw with EVWHS.