### PR TITLE
Fixed a with shapefile export

### DIFF
--- a/apps/omar-geoscript-app/grails-app/conf/application.yml
+++ b/apps/omar-geoscript-app/grails-app/conf/application.yml
@@ -217,7 +217,7 @@ wms:
     styles:
         byFileType:
             cadrg:
-                filter: file_type='cadrg222222222222'
+                filter: file_type='cadrg'
                 color:
                     r: 0
                     g: 255

--- a/apps/omar-geoscript-app/grails-app/conf/application.yml
+++ b/apps/omar-geoscript-app/grails-app/conf/application.yml
@@ -217,7 +217,7 @@ wms:
     styles:
         byFileType:
             cadrg:
-                filter: file_type='cadrg'
+                filter: file_type='cadrg222222222222'
                 color:
                     r: 0
                     g: 255
@@ -256,6 +256,19 @@ wms:
                     g: 0
                     b: 0
                     a: 255
+
+geoscript:
+    export:
+        # List of fields to exclude (from raster_entry table) during the shapefile export.
+        # This is needed because of the limitation of the column sizes in the outpuft .dbf
+        # file.  They only support 10 character column names.
+        excludes:
+          - 'country_code_tag_id'
+          - 'file_type_tag_id'
+          - 'mission_id_tag_id'
+          - 'product_id_tag_id'
+          - 'sensor_id_tag_id'
+          - 'target_id_tag_id'
 ---
 grails:
     cors:


### PR DESCRIPTION
**This PR addresses an issue with the column names not mapping correctly in the exported shapefiles .dbf file.**  

This causes problems when the  _raster_entry_ table is exported to a shapefile.  The .dbf that is created with the shapefile can only handle 10 character column names.  The raster entry table contains several columns with names longer than 10 characters.  Moreover, some of the columns in the raster entry table start with the same set of characters.

For example: 
mission_id and mission_id_tag_id

When geoscript maps the columns in raster_entry to the exported .dbf they end up looking like this for the above mentioned fields:

mission_id_tag_id --> mission_id1
mission_id --> mission_id1

At this point the data in the _raster_entry_ table does not map correctly to the corresponding columns in the dbf.

Therefore, I chose to modify the schema of the data, and remove the somewhat duplicitous fields.  I made it so that a configurable list of columns can be **excluded** during the export process.  There by allowing import fields to map correctly upon geoscript's data translation from Postgres to .dbf.

This fixes the problem with fields such as mission_id, sensor_id, target_id, etc not being present after export. 