### PR TITLE
gsd-5212 mission id to url

### DIFF
--- a/apps/omar-geoscript-app/chart/templates/configmap.yaml
+++ b/apps/omar-geoscript-app/chart/templates/configmap.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,53 +5,219 @@ metadata:
   labels:
     {{- include "omar-geoscript.labels" . | nindent 4 }}
 data:
-  application.yml: |-
-    
+  application.yaml: |-
+    about:
+      contactEmail: Kevin.Naquin@maxar.com
+      releaseName: HystericalHyena
+      releaseNumber: 1.0.0
+
+    geoscript:
+      evwhs:
+        url: 'https://evwhs.digitalglobe.com/mapservice/wmsaccess?connectid=a59618a4-3656-4b09-ba85-934f162bd9d6&version=1.3.0&request=GetCapabilities'
+        username: ''
+        password: ''
+      elasticsearch:
+        url: "https://logging-es.logging.svc.cluster.local:9200/project.omar-dev*/_search?pretty"
+      downloadURL: {{ .Values.downloadURL }}
+      downloadRootDir: {{ .Values.downloadRootDir }}
+      downloadMissions:
+      {{- range .Values.downloadMissions }}
+        - {{ . | quote }}
+      {{- end }}
+      downloadURL3D: {{ .Values.downloadURL3D }}
+      downloadRootDir3D: {{ .Values.downloadRootDir3D }}
+      downloadMissions3D:
+      {{- range .Values.downloadMissions3D }}
+        - {{ . | quote }}
+      {{- end }}
+    wfs:
+      featureTypeNamespaces:
+          - prefix: omar
+            uri: http://omar.ossim.org
+
+      datastores:
+          - namespaceId: omar
+            datastoreId: omar_prod
+            datastoreParams:
+              dbtype: postgis
+              host: {{ .Values.global.omarDb.host }}
+              port: "{{ .Values.global.omarDb.port }}"
+              database: {{ .Values.global.omarDb.name }}
+              user: {{ .Values.global.omarDb.user }}
+              passwd: {{ .Values.global.omarDb.password }}
+              'Expose primary keys': 'true'
+              namespace: http://omar.ossim.org
+
+      featureTypes:
+          - name: raster_entry
+            title: raster_entry
+            description: ''
+            keywords:
+              - omar
+              - raster_entry
+              - features
+            datastoreId: omar_prod
+
+          - name: video_data_set
+            title: video_data_set
+            description: ''
+            keywords:
+              - omar
+              - video_data_set
+              - features
+            datastoreId: omar_prod
+
+    wms:
+      styles:
+        byMissionId:
+          blacksky:
+            filter: mission_id='BlackSky'
+            color:
+              r: 0
+              g: 0
+              b: 0
+              a: 255
+          skysat:
+            filter: mission_id='SkySat'
+            color:
+              r: 0
+              g: 0
+              b: 255
+              a: 255
+          capella:
+            filter: mission_id='Capella'
+            color: orange
+          iceye:
+            filter: mission_id='ICEYE'
+            color: magenta
+          umbra:
+            filter: mission_id='UMBRA'
+            color: '#39FF14'
+        byFileType:
+          adrg:
+            filter: file_type='adrg'
+            color:
+              r: 50
+              g: 111
+              b: 111
+              a: 255
+          aaigrid:
+            filter: file_type='aaigrid'
+            color: pink
+          cadrg:
+            filter: file_type='cadrg'
+            color:
+              r: 0
+              g: 255
+              b: 255
+              a: 255
+          ccf:
+            filter: file_type='ccf'
+            color:
+              r: 128
+              g: 100
+              b: 255
+              a: 255
+          cib:
+            filter: file_type='cib'
+            color:
+              r: 0
+              g: 128
+              b: 128
+              a: 255
+          doqq:
+            filter: file_type='doqq'
+            color: purple
+          dted:
+            filter: file_type='dted'
+            color:
+              r: 0
+              g: 255
+              b: 0
+              a: 255
+          imagine_hfa:
+            filter: file_type='imagine_hfa'
+            color:
+              r: 192
+              g: 192
+              b: 192
+              a: 255
+          jpeg:
+            filter: file_type='jpeg'
+            color:
+              r: 255
+              g: 255
+              b: 0
+              a: 255
+          jpeg2000:
+            filter: file_type='jpeg2000'
+            color:
+              r: 255
+              g: 200
+              b: 0
+              a: 255
+          landsat7:
+            filter: file_type='landsat7'
+            color:
+              r: 255
+              g: 0
+              b: 255
+              a: 255
+          mrsid:
+            filter: file_type='mrsid'
+            color:
+              r: 0
+              g: 188
+              b: 0
+              a: 255
+          nitf:
+            filter: file_type='nitf'
+            color:
+              r: 0
+              g: 0
+              b: 255
+              a: 255
+          tiff:
+            filter: file_type='tiff'
+            color:
+              r: 255
+              g: 0
+              b: 0
+              a: 255
+          mpeg:
+            filter: filename LIKE '%mpg'
+            color:
+              r: 164
+              g: 254
+              b: 255
+              a: 255
+          unspecified:
+            filter: file_type='unspecified'
+            color: white
+
+    environments:
+      production:
+        dataSource:
+          pooled: true
+          jmxExport: true
+          driverClassName: ${omarDb.driver}
+          dialect:   ${omarDb.dialect}
+          url:      ${omarDb.url}
+          username: ${omarDb.username}
+          password: ${omarDb.password}
+
     omarDb:
-      name: {{ .Values.global.omarDb.name }}
+      host: {{ .Values.global.omarDb.host }}
       username: {{ .Values.global.omarDb.user }}
       password: {{ .Values.global.omarDb.password }}
-      host: {{ .Values.global.omarDb.host }}
-        
-    omar:
-      lite:
-        wms:
-          database:
-            name: {{ .Values.global.omarDb.name }}
-            username: {{ .Values.global.omarDb.user }}
-            password: {{ .Values.global.omarDb.password }}
-            host: {{ .Values.global.omarDb.host }}
-            port: {{ .Values.global.omarDb.port }}
-          styles:
-            blacksky:
-              filter: mission_id='BlackSky'
-              params:
-                bands: default
-                hist_op: auto-minmax
-                null_pixel_flip:  'false'
-            skysat-4band:
-              filter: mission_id='SkySat' and number_of_bands=4
-              params:
-                bands: 3,2,1
-                hist_op: auto-minmax
-                null_pixel_flip: 'false'
-            skysat:
-              filter: mission_id='SkySat'
-              params:
-                bands: default
-                hist_op: auto-minmax
-                null_pixel_flip:  'false'
-    micronaut:
-      config-client:
-        enabled: false
-      http:
-        client:
-          read-idle-timeout: -1
+      name: {{ .Values.global.omarDb.name }}
+      port: {{ .Values.global.omarDb.port }}
+      driver: org.postgresql.Driver
+      dialect: 'org.hibernate.spatial.dialect.postgis.PostgisDialect'
+      url: jdbc:postgresql://${omarDb.host}:${omarDb.port}/${omarDb.name}
 
-    kubernetes:
-      client:
-        secure: true
-        secrets:
-          enabled: true
-        discovery:
-          enabled: false
+    serverDomain: ossim.io
+    serverName: {{ .Values.global.hostname }}
+    serverNamePki: pki-omar.${serverDomain}
+
+    serverProtocol: https

--- a/apps/omar-geoscript-app/gradle.properties
+++ b/apps/omar-geoscript-app/gradle.properties
@@ -1,4 +1,4 @@
 groupName=io.ossim.omar.apps
 grailsConsoleVersion=2.1.1
-dockerBaseImage=docker://ossim-alpine-jdk17-runtime
-#dockerBaseImage=registry.iap.maxar.com/gegd/omar/ossim-alpine-jdk11-runtime/ossim-alpine-jdk17-runtime:0.9
+#dockerBaseImage=docker://ossim-alpine-jdk17-runtime
+dockerBaseImage=registry.iap.maxar.com/gegd/omar/ossim-alpine-jdk11-runtime/ossim-alpine-jdk17-runtime:0.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.0.0
+projectVersion=3.0.1
 
 grailsVersion=6.0.0
 grailsGradlePluginVersion=6.0.0


### PR DESCRIPTION
This PR add the ability to provide a download link for the P3DR data via the image_id field.  The service will check to see if the mission_id match an item in a provided list.  If there is a match it will override the image_id attribute with the specified download link.